### PR TITLE
Update handshake format check to use recent engine.io-client

### DIFF
--- a/lib/vantage-auth-basic.js
+++ b/lib/vantage-auth-basic.js
@@ -48,7 +48,7 @@ module.exports = function(vantage, options) {
       , retry = (options.retry === 0) ? 0 : (options.retry || 3)
       , retryTime = (options.retryTime || 1000)
       , handshake = (args.handshake)
-      , host = ((handshake) ? handshake.host : void 0)
+      , host = ((handshake) ? handshake.hostname : void 0)
       , port = ((handshake) ? handshake.port : void 0)
       , id = host + ":" + port
       , questions = [{

--- a/lib/vantage-auth-basic.js
+++ b/lib/vantage-auth-basic.js
@@ -48,7 +48,7 @@ module.exports = function(vantage, options) {
       , retry = (options.retry === 0) ? 0 : (options.retry || 3)
       , retryTime = (options.retryTime || 1000)
       , handshake = (args.handshake)
-      , host = ((handshake) ? handshake.hostname : void 0)
+      , host = ((handshake) ? (handshake.host || handshake.hostname) : void 0)
       , port = ((handshake) ? handshake.port : void 0)
       , id = host + ":" + port
       , questions = [{


### PR DESCRIPTION
The engine.io-client module uses a "hostname" key instead of a "host" key when initializing socket options. This affects this part of the vantage module (https://github.com/dthree/vantage/blob/master/lib/client.js#L81-L89) and this part (https://github.com/dthree/vantage/blob/master/lib/client.js#L285-L291), which in turn affects the hostname check in this module. The fix is to check for both "host" and "hostname".